### PR TITLE
postFleetsFleetidDevices: clarity improvements

### DIFF
--- a/src/torizon_cloud/torizon_api.py
+++ b/src/torizon_cloud/torizon_api.py
@@ -69,8 +69,10 @@ class TorizonAPI():
             payload = payload["data"]
 
         else:
-            if len(valid_payload) == 1:
-                payload = list(payload.values())[0]
+            # this is a workawound for postFleetsFleetidDevices, which takes an array instead of a json
+            first_value = list(payload.values())[0]
+            if (len(payload.keys()) == 1) and (type(first_value) == list):
+                payload = first_value
 
             payload = json.dumps(payload)
 


### PR DESCRIPTION
postFleetsFleetidDevices: for some reason,
this is the only one endpoint that takes an array directly, instead of a json with {key:array}.

